### PR TITLE
Cast also-load xml attribute to string

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Driver/XmlDriver.php
@@ -216,7 +216,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($attributes['also-load'])) {
-                    $mapping['alsoLoadFields'] = explode(',', $attributes['also-load']);
+                    $mapping['alsoLoadFields'] = explode(',', (string) $attributes['also-load']);
                 } elseif (isset($attributes['version'])) {
                     $mapping['version'] = ((string) $attributes['version'] === 'true');
                 } elseif (isset($attributes['lock'])) {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Need to cast also-xml to string before calling explode as it is a SimpleXmlElement object otherwise a fatal error is thrown.
